### PR TITLE
fix environemnt problems

### DIFF
--- a/R/spatialInference.R
+++ b/R/spatialInference.R
@@ -197,13 +197,13 @@ spatialInference <- function(spe,
     colnames(mm) <- gsub("-","_", colnames(mm))
     #create a formula without the first intercept column
     formula <- stats::as.formula(paste("Y ~", paste(colnames(mm)[c(-1)],
-                                                    collapse="+")))
+                                                    collapse="+")), env = emptyenv())
 
     if(!is.null(sample_id)){
       formula <- stats::as.formula(paste("Y ~",
                                   paste(c(colnames(mm)[c(-1)],
                                           paste0("s(",sample_id,", bs = 're')")),
-                                        collapse="+")))
+                                        collapse="+")), env = emptyenv())
     }
 
     #due to the removal of delta, rSeq can be less as well
@@ -440,7 +440,7 @@ exchangeSplineBasis <- function(mdl, var, bs){
     formulaVars <- formula.tools::rhs.vars(mdl$formula)
     formulaVars[1] <- newIntercept
   
-    newFormula <- stats::as.formula(paste("Y ~ ", paste(formulaVars, collapse = "+")))
+    newFormula <- stats::as.formula(paste("Y ~ ", paste(formulaVars, collapse = "+")), env = emptyenv())
 
     return(newFormula)
 }


### PR DESCRIPTION
issue: `functionalGam` returns a `mgcv::gam` object. This object has a formula attribute with a pointer to the global environment. This is a problem with large objects in the global environment as is the case with `SpatialExperiment` objects. Thank you @epurdom for spotting this and investigating it!

solution: in any `as.formula()` call one has to specify an empty environment as now fixed in `spatialInference`. thank you @Bisaloo for the fix!